### PR TITLE
fix: avoid duplicate fallback messages after timeout

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,8 +46,8 @@ export const createConfig = () =>
 				.description("默认Fallback消息前缀")
 				.default("[消息降级] "),
 			ForwardTimeoutSec: Schema.number()
-				.description("转发总超时时间（秒）- 含媒体下载与发送，超时则降级")
-				.default(30)
+				.description("转发慢速告警阈值（秒）- 超过该时间仍等待发送结果，避免重复消息")
+				.default(60)
 				.min(5)
 				.max(120),
 			MediaRelay: Schema.object({
@@ -61,7 +61,7 @@ export const createConfig = () =>
 					.max(180),
 				RequestTimeoutSec: Schema.number()
 					.description("媒体下载超时时间（秒）")
-					.default(15)
+				.default(30)
 					.min(3)
 					.max(120),
 				MaxFileSizeMB: Schema.number()

--- a/src/message.ts
+++ b/src/message.ts
@@ -70,12 +70,14 @@ export async function MessageForward(
 	const timeoutMs = (timeoutSec ?? 30) * 1000;
 	const deco = relayEnabled !== false ? MsgDecorator : MsgDecoratorNoRelay;
 
-	function withTimeout<T>(promise: Promise<T>): Promise<T> {
-		const timeoutPromise = new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error("forward total timeout")), timeoutMs),
-		);
+	function warnIfSlow<T>(promise: Promise<T>): Promise<T> {
+		const timer = setTimeout(() => {
+			logger.warn(
+				`[MessageForward] still pending after ${timeoutSec ?? 30}s; awaiting result to prevent duplicate delivery: ${node.Platform}`,
+			);
+		}, timeoutMs);
 
-		return Promise.race([promise, timeoutPromise]);
+		return promise.finally(() => clearTimeout(timer));
 	}
 
 	function sendDegraded(reason?: string) {
@@ -95,14 +97,11 @@ export async function MessageForward(
 		if (error instanceof MediaRelayError) {
 			return `[转发失败] ${error.userMessage} `;
 		}
-		if (error instanceof Error && error.message === "forward total timeout") {
-			return "[转发超时] ";
-		}
 
 		return undefined;
 	}
 
-	withTimeout(MessageSendWithDecorator(ctx, node, session, deco)).catch(
+	warnIfSlow(MessageSendWithDecorator(ctx, node, session, deco)).catch(
 		(firstError) => {
 			logger.error(
 				`ERROR:<MessageSend ${node.Platform}> ctx=${ctx} ${sessionTypeArray(session)} ${firstError}`,
@@ -112,7 +111,7 @@ export async function MessageForward(
 				logger.info(
 					`[MessageForward] relay failed, retrying without relay: ${node.Platform}`,
 				);
-				withTimeout(
+				warnIfSlow(
 					MessageSendWithDecorator(ctx, node, session, MsgDecoratorNoRelay),
 				).catch((secondError) => {
 					logger.error(


### PR DESCRIPTION
## Summary
- wait for the actual forwarding result instead of degrading solely on a local timeout
- retain a configurable slow-forwarding warning while preventing duplicate media messages
- extend default media download timeout to 30 seconds and the forwarding warning threshold to 60 seconds

## Test plan
- [x] `git diff --check`
- [ ] `npm run eslint` (blocked locally: missing `typescript-eslint` dependency)
- [ ] `npx tsc -p tsconfig.json` (blocked locally: existing TypeScript 6 `baseUrl` deprecation error)
